### PR TITLE
fix(db): removes redundancy in imagem column 

### DIFF
--- a/src/main/resources/db/migration/V1__create_table_item.sql
+++ b/src/main/resources/db/migration/V1__create_table_item.sql
@@ -5,5 +5,5 @@ CREATE TABLE item (
     tipo VARCHAR(255),
     quantidade INT NOT NULL,
     estado VARCHAR(100) NOT NULL,
-    imagem_item LONGTEXT
+    imagem LONGTEXT
 );

--- a/src/main/resources/db/migration/V2__rename_imagem_item_to_imagem.sql
+++ b/src/main/resources/db/migration/V2__rename_imagem_item_to_imagem.sql
@@ -1,1 +1,0 @@
-ALTER TABLE item CHANGE COLUMN imagem_item imagem LONGTEXT;


### PR DESCRIPTION
## O que foi feito
- Corrigida a definição da coluna `imagem` diretamente na V1
- Removida migration redundante que apenas renomeava `imagem_item` para `imagem`

## Por quê
A coluna já poderia ser criada com o nome correto desde o início, evitando uma alteração desnecessária no histórico de migrations.

## Impacto
- Nenhum impacto funcional
- Apenas limpeza e organização do histórico

## Observação
Caso o projeto já esteja em produção, essa alteração pode não ser adequada, pois altera o histórico de migrations já executadas.

---

Closes #1 